### PR TITLE
Fix/zarriopy3

### DIFF
--- a/docs/source/zarr_backend.rst
+++ b/docs/source/zarr_backend.rst
@@ -1,19 +1,22 @@
-============= 
-Zarr backend 
+=============
+Zarr backend
 =============
 
-The Zarr backend is an alternative format to store data in HDMF except for h5py.
+The Zarr backend is an alternative storage backend to store data using HDMF via the Zarr library.
 
-Currently, Zarr backend supports functions:
+Currently, the Zarr backend supports:
 
-- Write/Read basic datatypes, strings and compound data types 
+- Write/Read of basic datatypes, strings and compound data types
 - Chunking
-- Link
-- Object reference
+- Links
+- Object references
 
-Functions which are in h5py backend but not supported by the Zarr backend are:
+The following features available in the h5py backend are not yet supported by the Zarr backend:
 
 - Compression
-- Region reference
+- Region reference (see ``ZarrIO.__get_ref``)
+- Iterative data write using AbstractDataChunkIterator
+- loading/writing namespaces/specifications
+
 
 **Note:** The link and reference in Zarr backend are OS independent. The backend reserves attributes to store the paths of the target objects in the two functions.

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ six==1.11.0
 urllib3==1.24.2
 pandas==0.23.4
 zarr==2.3.2
+numcodecs==0.6.3

--- a/src/hdmf/backends/zarr/zarr_tools.py
+++ b/src/hdmf/backends/zarr/zarr_tools.py
@@ -516,14 +516,12 @@ class ZarrIO(HDMFIO):
         if ret is not None:
             return ret
 
-        kwargs = {
-            "attributes": self.__read_attrs(zarr_obj),
-            "dtype": zarr_obj.attrs['zarr_dtype'],
-            "maxshape": zarr_obj.shape,
-            "chunks": not (zarr_obj.shape == zarr_obj.chunks)
-        }
+        kwargs = {"attributes": self.__read_attrs(zarr_obj),
+                  "dtype": zarr_obj.attrs['zarr_dtype'],
+                  "maxshape": zarr_obj.shape,
+                  "chunks": not (zarr_obj.shape == zarr_obj.chunks),
+                  "source": self.__path}
 
-        kwargs['source'] = self.__path
         # data = deepcopy(zarr_obj[:])
         data = zarr_obj
         # kwargs['data'] = zarr_obj[:]

--- a/src/hdmf/backends/zarr/zarr_tools.py
+++ b/src/hdmf/backends/zarr/zarr_tools.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 
 import zarr
 import tempfile
-from six import raise_from, text_type, string_types, binary_type
+from six import raise_from, text_type, string_types, binary_type, text_type
 from .zarr_utils import ZarrDataIO
 from .zarr_utils import ZarrReference
 from ..io import HDMFIO
@@ -29,7 +29,7 @@ class ZarrIO(HDMFIO):
             {'name': 'manager', 'type': BuildManager, 'doc': 'the BuildManager to use for I/O', 'default': None},
             {'name': 'mode', 'type': str,
              'doc': 'the mode to open the Zarr file with, one of ("w", "r", "r+", "a", "w-")'},
-            {'name': 'comm', 'type': 'Intracomm', 
+            {'name': 'comm', 'type': 'Intracomm',
              'doc': 'the MPI communicator to use for parallel I/O', 'default': None})
     def __init__(self, **kwargs):
         path, manager, mode, comm = popargs('path', 'manager', 'mode', 'comm', kwargs)
@@ -51,10 +51,10 @@ class ZarrIO(HDMFIO):
             open_flag = self.__mode
             if self.__comm:
                 sync_path = tempfile.mkdtemp()
-                synchronizer = zarr.ProcessSynchronizer(sync_path) 
+                synchronizer = zarr.ProcessSynchronizer(sync_path)
                 kwargs = {'synchronizer': synchronizer}
             else:
-                kwargs = {} 
+                kwargs = {}
             self.__file = zarr.open(self.__path, self.__mode, **kwargs)
 
     def close(self):
@@ -303,15 +303,14 @@ class ZarrIO(HDMFIO):
         "int8": np.int8,
         "bool": np.bool_,
         "bool_": np.bool_,
-        "text": str,
-        "text": str,
-        "utf": unicode,
-        "utf8": unicode,
-        "utf-8": unicode,
-        "ascii": str,
-        "str": str,
-        "isodatetime": str,
-        "string_": str,
+        "text": binary_type,
+        "utf": text_type,
+        "utf8": text_type,
+        "utf-8": text_type,
+        "ascii": binary_type,
+        "str": binary_type,
+        "isodatetime": binary_type,
+        "string_": binary_type,
         "uint32": np.uint32,
         "uint16": np.uint16,
         "uint8": np.uint8,
@@ -390,8 +389,8 @@ class ZarrIO(HDMFIO):
                 raise_from(Exception(msg), exc)
 
         type_str = cls.__serial_dtype__(dtype)
-        
-            
+
+
         if 'shape' in io_settings:
             data_shape = io_settings.pop('shape')
         elif isinstance(dtype, np.dtype):
@@ -450,7 +449,7 @@ class ZarrIO(HDMFIO):
         path = zarr_obj.path
         path = os.path.join(fpath, path)
         self.__built.setdefault(path, builder)
-        
+
     def __get_built(self, zarr_obj):
         fpath = zarr_obj.store.path
         path = zarr_obj.path
@@ -461,7 +460,7 @@ class ZarrIO(HDMFIO):
         ret = self.__get_built(zarr_obj)
         if ret != None:
             return ret
-        
+
         kwargs = {
             "attributes": self.__read_attrs(zarr_obj),
             "groups": dict(),
@@ -513,7 +512,7 @@ class ZarrIO(HDMFIO):
         ret = self.__get_built(zarr_obj)
         if ret != None:
             return ret
-        
+
         kwargs = {
             "attributes": self.__read_attrs(zarr_obj),
             "dtype": zarr_obj.attrs['zarr_dtype'],

--- a/src/hdmf/backends/zarr/zarr_tools.py
+++ b/src/hdmf/backends/zarr/zarr_tools.py
@@ -9,19 +9,20 @@ from copy import deepcopy
 
 import zarr
 import tempfile
-from six import raise_from, text_type, string_types, binary_type, text_type
+from six import raise_from, string_types, binary_type, text_type
 from .zarr_utils import ZarrDataIO
 from .zarr_utils import ZarrReference
 from ..io import HDMFIO
-from ...utils import docval, getargs, popargs, call_docval_func
+from ...utils import docval, getargs, popargs  # , call_docval_func
 from ...build import Builder, GroupBuilder, DatasetBuilder, LinkBuilder, BuildManager,\
-                     RegionBuilder, ReferenceBuilder, TypeMap, ObjectMapper
+                     RegionBuilder, ReferenceBuilder, TypeMap  # , ObjectMapper
 from ...container import Container
-from ...data_utils import AbstractDataChunkIterator, get_shape
+from ...data_utils import get_shape  # , AbstractDataChunkIterator,
 from ...spec import RefSpec, DtypeSpec, NamespaceCatalog
 
 
 ROOT_NAME = 'root'
+
 
 class ZarrIO(HDMFIO):
 
@@ -48,7 +49,6 @@ class ZarrIO(HDMFIO):
 
     def open(self):
         if self.__file is None:
-            open_flag = self.__mode
             if self.__comm:
                 sync_path = tempfile.mkdtemp()
                 synchronizer = zarr.ProcessSynchronizer(sync_path)
@@ -134,8 +134,7 @@ class ZarrIO(HDMFIO):
         else:
             return dtype == DatasetBuilder.OBJECT_REF_TYPE or dtype == DatasetBuilder.REGION_REF_TYPE
 
-
-    #### Haven't implemented RegionReference
+    # TODO Haven't implemented RegionReference
     @docval({'name': 'container', 'type': (Builder, Container, ReferenceBuilder), 'doc': 'the object to reference'},
             {'name': 'region', 'type': (slice, list, tuple), 'doc': 'the region reference indexing object',
              'default': None},
@@ -152,8 +151,9 @@ class ZarrIO(HDMFIO):
         else:
             builder = self.manager.build(container)
         path = self.__get_path(builder)
-        if isinstance(container, RegionBuilder):
-            region = container.region
+        # TODO Add to get region for region references
+        # if isinstance(container, RegionBuilder):
+        #    region = container.region
         source = builder.source
         return ZarrReference(source, path)
 
@@ -201,18 +201,18 @@ class ZarrIO(HDMFIO):
         linked = False
 
         if isinstance(data, Array):
-            ## copy the dataset
+            # copy the dataset
             if link_data:
                 self.__add_link__(parent, data.store.path, data.name, name)
                 linked = True
             else:
-                zarr.copy(data, parent, name = name)
+                zarr.copy(data, parent, name=name)
                 dset = parent[name]
         elif isinstance(options['dtype'], list):
 
             refs = list()
             type_str = list()
-            for i ,dts in enumerate(options['dtype']):
+            for i, dts in enumerate(options['dtype']):
                 if self.__is_ref(dts['dtype']):
                     refs.append(i)
                     ref_tmp = self.__get_ref(data[0][i])
@@ -227,10 +227,12 @@ class ZarrIO(HDMFIO):
                     type_str.append(self.__serial_dtype__(t)[0])
 
             if len(refs) > 0:
-                dset = parent.require_dataset(name, shape = (len(data), ), dtype = object
-                                            , compressor = None
-                                            , object_codec = numcodecs.JSON()
-                                            , **options['io_settings'])
+                dset = parent.require_dataset(name,
+                                              shape=(len(data), ),
+                                              dtype=object,
+                                              compressor=None,
+                                              object_codec=numcodecs.JSON(),
+                                              **options['io_settings'])
                 builder.written = True
                 dset.attrs['zarr_dtype'] = type_str
                 for j, item in enumerate(data):
@@ -239,7 +241,7 @@ class ZarrIO(HDMFIO):
                         new_item[i] = self.__get_ref(item[i])
                     dset[j] = new_item
             else:
-                ### write a compound datatype
+                # write a compound datatype
                 dset = self.__list_fill__(parent, name, data, options)
 
         elif self.__is_ref(options['dtype']):
@@ -253,7 +255,7 @@ class ZarrIO(HDMFIO):
                 refs = self.__get_ref(data.builder)
             elif options['dtype'] == 'region':
                 shape = (len(data), )
-                typer_str = 'region'
+                type_str = 'region'
                 refs = list()
                 for item in data:
                     refs.append(self.__get_ref(item.builder, item.region))
@@ -264,10 +266,12 @@ class ZarrIO(HDMFIO):
                 for item in data:
                     refs.append(self.__get_ref(item))
 
-            dset = parent.require_dataset(name, shape = shape, dtype = object
-                                            , compressor = None
-                                            , object_codec = numcodecs.JSON()
-                                            , **options['io_settings'])
+            dset = parent.require_dataset(name,
+                                          shape=shape,
+                                          dtype=object,
+                                          compressor=None,
+                                          object_codec=numcodecs.JSON(),
+                                          **options['io_settings'])
             builder.written = True
             dset.attrs['zarr_dtype'] = type_str
             if hasattr(refs, '__len__'):
@@ -276,7 +280,7 @@ class ZarrIO(HDMFIO):
             else:
                 dset[0] = refs
 
-        ## write a 'regular' dataset without DatasetIO info
+        # write a 'regular' dataset without DatasetIO info
         else:
             if isinstance(data, (text_type, binary_type)):
                 dset = self.__scalar_fill__(parent, name, data, options)
@@ -335,7 +339,7 @@ class ZarrIO(HDMFIO):
                     item['dtype'] = cls.__serial_dtype__(dtype[n])
                     ret.append(item)
                 return ret
-        ## Dont work when Reference in compound datatype
+        # TODO Does not work when Reference in compound datatype
         elif dtype == ZarrReference:
             return 'object'
 
@@ -390,7 +394,6 @@ class ZarrIO(HDMFIO):
 
         type_str = cls.__serial_dtype__(dtype)
 
-
         if 'shape' in io_settings:
             data_shape = io_settings.pop('shape')
         elif isinstance(dtype, np.dtype):
@@ -401,9 +404,9 @@ class ZarrIO(HDMFIO):
         if isinstance(dtype, np.dtype):
             dtype = object
             io_settings['object_codec'] = numcodecs.JSON()
-            #chunks = io_settings['chunks']
+            # chunks = io_settings['chunks']
 
-        dset = parent.require_dataset(name, shape = data_shape, dtype = dtype, compressor = None, **io_settings)
+        dset = parent.require_dataset(name, shape=data_shape, dtype=dtype, compressor=None, **io_settings)
         dset.attrs['zarr_dtype'] = type_str
         if dtype == object:
             corr = []
@@ -435,7 +438,7 @@ class ZarrIO(HDMFIO):
             except Exception as exc:
                 msg = 'cannot add %s to %s - could not determine type' % (name, parent.name)  # noqa: F821
                 raise_from(Exception(msg), exc)
-        dset = parent.require_dataset(name, shape=(1, ), dtype = dtype, compressor = None, **io_settings)
+        dset = parent.require_dataset(name, shape=(1, ), dtype=dtype, compressor=None, **io_settings)
         dset[:] = data
         return dset
 
@@ -458,7 +461,7 @@ class ZarrIO(HDMFIO):
 
     def __read_group(self, zarr_obj, name=None):
         ret = self.__get_built(zarr_obj)
-        if ret != None:
+        if ret is not None:
             return ret
 
         kwargs = {
@@ -471,17 +474,17 @@ class ZarrIO(HDMFIO):
         if name is None:
             name = str(os.path.basename(zarr_obj.name))
 
-        ##read sub groups
+        # read sub groups
         for sub_name, sub_group in zarr_obj.groups():
             sub_builder = self.__read_group(sub_group, sub_name)
             kwargs['groups'][sub_builder.name] = sub_builder
 
-        ##read sub datasets
+        # read sub datasets
         for sub_name, sub_array in zarr_obj.arrays():
             sub_builder = self.__read_dataset(sub_array, sub_name)
             kwargs['datasets'][sub_builder.name] = sub_builder
 
-        ##read links
+        # read links
         if 'zarr_link' in zarr_obj.attrs:
             links = zarr_obj.attrs['zarr_link']
             for link in links:
@@ -493,12 +496,12 @@ class ZarrIO(HDMFIO):
                 else:
                     l_path = str(link['source'] + "/" + link['path'])
                 target_name = str(os.path.basename(l_path))
-                target_zarr_obj = zarr.open(l_path, mode = 'r')
+                target_zarr_obj = zarr.open(l_path, mode='r')
                 if isinstance(target_zarr_obj, Group):
                     builder = self.__read_group(target_zarr_obj, target_name)
                 else:
                     builder = self.__read_dataset(target_zarr_obj, target_name)
-                link_builder = LinkBuilder(builder, l_name, source = self.__path)
+                link_builder = LinkBuilder(builder, l_name, source=self.__path)
                 link_builder.written = True
                 kwargs['links'][target_name] = link_builder
 
@@ -510,7 +513,7 @@ class ZarrIO(HDMFIO):
 
     def __read_dataset(self, zarr_obj, name):
         ret = self.__get_built(zarr_obj)
-        if ret != None:
+        if ret is not None:
             return ret
 
         kwargs = {
@@ -521,16 +524,16 @@ class ZarrIO(HDMFIO):
         }
 
         kwargs['source'] = self.__path
-        #data = deepcopy(zarr_obj[:])
+        # data = deepcopy(zarr_obj[:])
         data = zarr_obj
-        #kwargs['data'] = zarr_obj[:]
+        # kwargs['data'] = zarr_obj[:]
 
         dtype = kwargs['dtype']
         obj_refs = False
         reg_refs = False
         has_reference = False
         if isinstance(dtype, list):
-            ##compound data type
+            # compound data type
             obj_refs = list()
             reg_refs = list()
             for i, dts in enumerate(dtype):
@@ -542,7 +545,7 @@ class ZarrIO(HDMFIO):
                     has_reference = True
 
         elif self.__is_ref(dtype):
-            ### reference array
+            # reference array
             has_reference = True
             if dtype == DatasetBuilder.OBJECT_REF_TYPE:
                 obj_refs = True
@@ -593,14 +596,12 @@ class ZarrIO(HDMFIO):
             if source is not None and source != "":
                 path = source + path
             target_name = str(os.path.basename(path))
-            target_zarr_obj = zarr.open(str(path), mode = 'r')
+            target_zarr_obj = zarr.open(str(path), mode='r')
 
             o = data
             for i in range(0, len(p)-1):
                 o = data[p[i]]
             o[p[-1]] = self.__read_dataset(target_zarr_obj, target_name)
-
-
 
     def __read_attrs(self, zarr_obj):
         ret = dict()

--- a/src/hdmf/backends/zarr/zarr_utils.py
+++ b/src/hdmf/backends/zarr/zarr_utils.py
@@ -3,11 +3,13 @@ import zarr
 import numcodecs
 import numpy as np
 from collections import Iterable
+import json
 
 from ...data_utils import DataIO
-from ...utils import docval, getargs, popargs, call_docval_func
+from ...utils import docval, getargs, call_docval_func  # , popargs
 
 from ...spec import SpecWriter, SpecReader
+
 
 class ZarrSpecWriter(SpecWriter):
 
@@ -24,9 +26,11 @@ class ZarrSpecWriter(SpecWriter):
 
     def __write(self, d, name):
         data = self.stringify(d)
-        dset = self.__group.require_dataset(name, shape = (1, ), dtype = object
-                                            , object_codec = numcodecs.JSON()
-                                            , compressor = None)
+        dset = self.__group.require_dataset(name,
+                                            shape=(1, ),
+                                            dtype=object,
+                                            object_codec=numcodecs.JSON(),
+                                            compressor=None)
         dset[0] = data
         return dset
 
@@ -35,6 +39,7 @@ class ZarrSpecWriter(SpecWriter):
 
     def write_namespace(self, namespace, path):
         return self.__write({'namespaces': [namespace]}, path)
+
 
 class ZarrSpecReader(SpecReader):
 
@@ -58,6 +63,7 @@ class ZarrSpecReader(SpecReader):
         ret = ret['namespaces']
         return ret
 
+
 class ZarrDataIO(DataIO):
     """
     Wrap data arrays for write via ZarrIO to customize I/O behavior, such as compression and chunking
@@ -76,7 +82,7 @@ class ZarrDataIO(DataIO):
              'type': None,
              'doc': 'Value to be returned when reading uninitialized parts of the dataset',
              'default': None},
-             {'name': 'link_data',
+            {'name': 'link_data',
              'type': bool,
              'doc': 'If data is an zarr.Array should it be linked to or copied. NOTE: This parameter is only ' +
                     'allowed if data is an zarr.Array',
@@ -93,7 +99,6 @@ class ZarrDataIO(DataIO):
         if fill_value is not None:
             self.__iosettings['fill_value'] = fill_value
 
-
     @property
     def link_data(self):
         return self.__link_data
@@ -101,6 +106,7 @@ class ZarrDataIO(DataIO):
     @property
     def io_settings(self):
         return self.__iosettings
+
 
 class ZarrReference(dict):
 
@@ -122,6 +128,7 @@ class ZarrReference(dict):
     @property
     def source(self):
         return super(ZarrReference, self).__getitem__('source')
+
     @property
     def path(self):
         return super(ZarrReference, self).__getitem__('path')

--- a/tests/unit/test_io_zarr.py
+++ b/tests/unit/test_io_zarr.py
@@ -3,14 +3,13 @@ import os
 import numpy as np
 import shutil
 from six import text_type
-from numbers import Number
 import zarr
 
-from hdmf.build import GroupBuilder, DatasetBuilder, LinkBuilder, ReferenceBuilder
+from hdmf.build import GroupBuilder, DatasetBuilder, ReferenceBuilder  # , LinkBuilder
 from hdmf.backends.zarr import ZarrIO
 from hdmf.backends.zarr import ZarrDataIO
 from tests.unit.test_io_hdf5_h5tools import _get_manager
-from tests.unit.test_utils import Foo
+
 
 class GroupBuilderTestCase(unittest.TestCase):
     '''
@@ -25,10 +24,10 @@ class GroupBuilderTestCase(unittest.TestCase):
                 return True
         return False
 
-    def __convert_h5_scalar(self, obj):
-        if isinstance(obj, Dataset):
-            return obj[...]
-        return obj
+    # def __convert_h5_scalar(self, obj):
+    #    if isinstance(obj, Dataset):
+    #        return obj[...]
+    #    return obj
 
     def __compare_attr_dicts(self, a, b):
         reasons = list()
@@ -54,24 +53,25 @@ class GroupBuilderTestCase(unittest.TestCase):
             reasons.append("dataset '%s' not equal" % a.name)
         return reasons
 
+
 class TestZarrWriter(unittest.TestCase):
+
     def setUp(self):
         self.manager = _get_manager()
         self.path = "test_io.zarr"
 
     def tearDown(self):
-        return
-
-    def createGroupBuilder(self):
         if os.path.exists(self.path):
             shutil.rmtree(self.path)
+
+    def createGroupBuilder(self):
         self.foo_builder = GroupBuilder('foo1',
                                         attributes={'data_type': 'Foo',
                                                     'namespace': 'test_core',
                                                     'attr1': 17.5},
                                         datasets={'my_data': self.__dataset_builder})
-        #self.foo = Foo('foo1', self.__dataset_builder.data, attr1="bar", attr2=17, attr3=3.14)
-        #self.manager.prebuilt(self.foo, self.foo_builder)
+        # self.foo = Foo('foo1', self.__dataset_builder.data, attr1="bar", attr2=17, attr3=3.14)
+        # self.manager.prebuilt(self.foo, self.foo_builder)
         self.builder = GroupBuilder(
             'root',
             source=self.path,
@@ -82,80 +82,7 @@ class TestZarrWriter(unittest.TestCase):
                                                       groups={'foo1': self.foo_builder})})},
             attributes={'data_type': 'FooFile'})
 
-    def test_write_int(self):
-        data = np.arange(100, 200, 10).reshape(2, 5)
-        self.__dataset_builder = DatasetBuilder('my_data', data, attributes={'attr2': 17})
-        self.createGroupBuilder()
-        writer = ZarrIO(self.path, manager = self.manager, mode = 'a')
-        writer.write_builder(self.builder)
-        writer.close()
-
-    def test_write_compound(self):
-        data = [
-            (1, 'Allen'),
-            (2, 'Bob'),
-            (3, 'Mike'),
-            (4, 'Jenny')
-        ]
-
-        data_type= [{'name': 'id', 'dtype': 'int'}, {'name': 'name', 'dtype': 'str'}]
-        self.__dataset_builder = DatasetBuilder('my_data', data, dtype = data_type)
-        self.createGroupBuilder()
-        writer = ZarrIO(self.path, manager = self.manager, mode = 'a')
-        writer.write_builder(self.builder)
-        writer.close()
-
-    def test_write_chunk(self):
-        data = np.arange(100, 200, 10).reshape(2, 5)
-        data_io = ZarrDataIO(data = data, chunks = (1, 5), fillvalue = -1)
-        self.__dataset_builder = DatasetBuilder('my_data', data_io, attributes={'attr2': 17})
-        self.createGroupBuilder()
-        writer = ZarrIO(self.path, manager = self.manager, mode = 'a')
-        writer.write_builder(self.builder)
-        writer.close()
-
-    def test_write_strings(self):
-        data = [
-            ['a', 'aa', 'aaa', 'aaaa', 'aaaaa'],
-            ['b', 'bb', 'bbb', 'bbbb', 'bbbbb']
-        ]
-        self.__dataset_builder = DatasetBuilder('my_data', data, attributes={'attr2': 17})
-        self.createGroupBuilder()
-        writer = ZarrIO(self.path, manager = self.manager, mode = 'a')
-        writer.write_builder(self.builder)
-        writer.close()
-
-    def test_write_links(self):
-        data = np.arange(100, 200, 10).reshape(2, 5)
-        self.__dataset_builder = DatasetBuilder('my_data', data, attributes={'attr2': 17})
-        self.createGroupBuilder()
-        link_parent = self.builder['test_bucket']
-        link_parent.add_link(self.foo_builder, 'my_link')
-        link_parent.add_link(self.__dataset_builder, 'my_dataset')
-        writer = ZarrIO(self.path, manager = self.manager, mode = 'a')
-        writer.write_builder(self.builder)
-        writer.close()
-
-    def test_write_link_array(self):
-        data = np.arange(100, 200, 10).reshape(2, 5)
-        self.__dataset_builder = DatasetBuilder('my_data', data, attributes={'attr2': 17})
-        self.createGroupBuilder()
-        writer = ZarrIO(self.path, manager = self.manager, mode = 'a')
-        writer.write_builder(self.builder)
-        zarr_array = zarr.open(self.path+"/test_bucket/foo_holder/foo1/my_data", mode = 'r')
-        link_io = ZarrDataIO(data = zarr_array, link_data = True)
-        link_dataset = DatasetBuilder('dataset_link', link_io)
-        self.builder['test_bucket'].set_dataset(link_dataset)
-        writer.write_builder(self.builder)
-        writer.close()
-
-        reader = ZarrIO(self.path, manager = self.manager, mode = 'r')
-        self.root = reader.read_builder()
-        read_link = self.root['test_bucket/dataset_link']
-
-    def test_write_reference(self):
-        if os.path.exists(self.path):
-            shutil.rmtree(self.path)
+    def getReferenceBuilder(self):
         data_1 = np.arange(100, 200, 10).reshape(2, 5)
         data_2 = np.arange(0, 200, 10).reshape(4, 5)
         dataset_1 = DatasetBuilder('dataset_1', data_1)
@@ -166,15 +93,14 @@ class TestZarrWriter(unittest.TestCase):
         ref_data = [ref_dataset_1, ref_dataset_2]
         dataset_ref = DatasetBuilder('ref_dataset', ref_data, dtype='object')
 
-        builder = GroupBuilder('root', source = self.path,
-                                datasets = {'dataset_1':dataset_1, 'dataset_2':dataset_2, 'ref_dataset':dataset_ref})
-        writer = ZarrIO(self.path, manager = self.manager, mode = 'a')
-        writer.write_builder(builder)
-        writer.close()
+        builder = GroupBuilder('root',
+                               source=self.path,
+                               datasets={'dataset_1': dataset_1,
+                                         'dataset_2': dataset_2,
+                                         'ref_dataset': dataset_ref})
+        return builder
 
-    def test_write_reference_compound(self):
-        if os.path.exists(self.path):
-            shutil.rmtree(self.path)
+    def getReferenceCompoundBuilder(self):
         data_1 = np.arange(100, 200, 10).reshape(2, 5)
         data_2 = np.arange(0, 200, 10).reshape(4, 5)
         dataset_1 = DatasetBuilder('dataset_1', data_1)
@@ -186,46 +112,151 @@ class TestZarrWriter(unittest.TestCase):
             (1, 'dataset_1', ref_dataset_1),
             (2, 'dataset_2', ref_dataset_2)
         ]
-        ref_data_type = [{'name': 'id', 'dtype': 'int'}, {'name': 'name', 'dtype': str}, {'name': 'reference', 'dtype': 'object'}]
+        ref_data_type = [{'name': 'id', 'dtype': 'int'},
+                         {'name': 'name', 'dtype': str},
+                         {'name': 'reference', 'dtype': 'object'}]
         dataset_ref = DatasetBuilder('ref_dataset', ref_data, dtype=ref_data_type)
-        builder = GroupBuilder('root', source = self.path,
-                                datasets = {'dataset_1':dataset_1, 'dataset_2':dataset_2, 'ref_dataset':dataset_ref})
-        writer = ZarrIO(self.path, manager = self.manager, mode = 'a')
+        builder = GroupBuilder('root',
+                               source=self.path,
+                               datasets={'dataset_1': dataset_1,
+                                         'dataset_2': dataset_2,
+                                         'ref_dataset': dataset_ref})
+        return builder
+
+    def read_test_dataset(self):
+        reader = ZarrIO(self.path, manager=self.manager, mode='r')
+        self.root = reader.read_builder()
+        dataset = self.root['test_bucket/foo_holder/foo1/my_data']
+        return dataset
+
+    def read(self):
+        reader = ZarrIO(self.path, manager=self.manager, mode='r')
+        self.root = reader.read_builder()
+
+    def test_write_int(self, test_data=None):
+        data = np.arange(100, 200, 10).reshape(2, 5) if test_data is None else test_data
+        self.__dataset_builder = DatasetBuilder('my_data', data, attributes={'attr2': 17})
+        self.createGroupBuilder()
+        writer = ZarrIO(self.path, manager=self.manager, mode='a')
+        writer.write_builder(self.builder)
+        writer.close()
+
+    def test_write_compound(self, test_data=None):
+        """
+        :param test_data: Optional list of the form [(1, 'STR1'), (2, 'STR2')], i.e., a list of tuples where
+                          each tuple consists of an int and a string
+        :return:
+        """
+        data = [(1, 'Allen'),
+                (2, 'Bob'),
+                (3, 'Mike'),
+                (4, 'Jenny')] if test_data is None else test_data
+        data_type = [{'name': 'id', 'dtype': 'int'},
+                     {'name': 'name', 'dtype': 'str'}]
+        self.__dataset_builder = DatasetBuilder('my_data', data, dtype=data_type)
+        self.createGroupBuilder()
+        writer = ZarrIO(self.path, manager=self.manager, mode='a')
+        writer.write_builder(self.builder)
+        writer.close()
+
+    def test_write_chunk(self, test_data=None):
+        data = np.arange(100, 200, 10).reshape(2, 5) if test_data is None else test_data
+        data_io = ZarrDataIO(data=data, chunks=(1, 5), fillvalue=-1)
+        self.__dataset_builder = DatasetBuilder('my_data', data_io, attributes={'attr2': 17})
+        self.createGroupBuilder()
+        writer = ZarrIO(self.path, manager=self.manager, mode='a')
+        writer.write_builder(self.builder)
+        writer.close()
+
+    def test_write_strings(self, test_data=None):
+        data = [['a', 'aa', 'aaa', 'aaaa', 'aaaaa'],
+                ['b', 'bb', 'bbb', 'bbbb', 'bbbbb']] if test_data is None else test_data
+        self.__dataset_builder = DatasetBuilder('my_data', data, attributes={'attr2': 17})
+        self.createGroupBuilder()
+        writer = ZarrIO(self.path, manager=self.manager, mode='a')
+        writer.write_builder(self.builder)
+        writer.close()
+
+    def test_write_links(self, test_data=None):
+        data = np.arange(100, 200, 10).reshape(2, 5) if test_data is None else test_data
+        self.__dataset_builder = DatasetBuilder('my_data', data, attributes={'attr2': 17})
+        self.createGroupBuilder()
+        link_parent = self.builder['test_bucket']
+        link_parent.add_link(self.foo_builder, 'my_link')
+        link_parent.add_link(self.__dataset_builder, 'my_dataset')
+        writer = ZarrIO(self.path, manager=self.manager, mode='a')
+        writer.write_builder(self.builder)
+        writer.close()
+
+    def test_write_link_array(self):
+        data = np.arange(100, 200, 10).reshape(2, 5)
+        self.__dataset_builder = DatasetBuilder('my_data', data, attributes={'attr2': 17})
+        self.createGroupBuilder()
+        writer = ZarrIO(self.path, manager=self.manager, mode='a')
+        writer.write_builder(self.builder)
+        zarr_array = zarr.open(self.path+"/test_bucket/foo_holder/foo1/my_data", mode='r')
+        link_io = ZarrDataIO(data=zarr_array, link_data=True)
+        link_dataset = DatasetBuilder('dataset_link', link_io)
+        self.builder['test_bucket'].set_dataset(link_dataset)
+        writer.write_builder(self.builder)
+        writer.close()
+
+        reader = ZarrIO(self.path, manager=self.manager, mode='r')
+        self.root = reader.read_builder()
+        read_link = self.root['test_bucket/dataset_link']
+        read_link_data = read_link['builder']['data'][:]
+        self.assertTrue(np.all(data == read_link_data))
+
+    def test_write_reference(self):
+        builder = self.getReferenceBuilder()
+        writer = ZarrIO(self.path,
+                        manager=self.manager,
+                        mode='a')
         writer.write_builder(builder)
         writer.close()
 
-    def read_and_print(self):
-        reader = ZarrIO(self.path, manager = self.manager, mode = 'r')
-        self.root = reader.read_builder()
-        dataset = self.root['test_bucket/foo_holder/foo1/my_data']
-        print(dataset)
-        print(dataset.data[()])
-        print(dataset.dtype)
-
-    def read(self):
-        reader = ZarrIO(self.path, manager = self.manager, mode = 'r')
-        self.root = reader.read_builder()
+    def test_write_reference_compound(self):
+        builder = self.getReferenceCompoundBuilder()
+        writer = ZarrIO(self.path, manager=self.manager, mode='a')
+        writer.write_builder(builder)
+        writer.close()
 
     def test_read_int(self):
-        self.test_write_int()
-        self.read_and_print()
+        test_data = np.arange(100, 200, 10).reshape(5, 2)
+        self.test_write_int(test_data=test_data)
+        dataset = self.read_test_dataset()['data'][:]
+        self.assertTrue(np.all(test_data == dataset))
 
     def test_read_chunk(self):
-        self.test_write_chunk()
-        self.read_and_print()
+        test_data = np.arange(100, 200, 10).reshape(5, 2)
+        self.test_write_chunk(test_data=test_data)
+        dataset = self.read_test_dataset()['data'][:]
+        self.assertTrue(np.all(test_data == dataset))
 
     def test_read_strings(self):
-        self.test_write_strings()
-        self.read_and_print()
+        test_data = [['a1', 'aa2', 'aaa3', 'aaaa4', 'aaaaa5'],
+                     ['b1', 'bb2', 'bbb3', 'bbbb4', 'bbbbb5']]
+        self.test_write_strings(test_data=test_data)
+        dataset = self.read_test_dataset()['data'][:]
+        self.assertTrue(np.all(np.asarray(test_data) == dataset))
 
     def test_read_compound(self):
-        self.test_write_compound()
-        self.read_and_print()
+        test_data = [(1, 'Allen1'),
+                     (2, 'Bob1'),
+                     (3, 'Mike1')]
+        self.test_write_compound(test_data=test_data)
+        dataset = self.read_test_dataset()['data']
+        self.assertTupleEqual(test_data[0], tuple(dataset[0]))
+        self.assertTupleEqual(test_data[1], tuple(dataset[1]))
+        self.assertTupleEqual(test_data[2], tuple(dataset[2]))
 
     def test_read_link(self):
-        self.test_write_links()
+        test_data = np.arange(100, 200, 10).reshape(5, 2)
+        self.test_write_links(test_data=test_data)
         self.read()
-        print(self.root['test_bucket'].links['my_dataset'].builder.data[()])
+        link_data = self.root['test_bucket'].links['my_dataset'].builder.data[()]
+        self.assertTrue(np.all(np.asarray(test_data) == link_data))
+        # print(self.root['test_bucket'].links['my_dataset'].builder.data[()])
 
     def test_read_link_buf(self):
         data = np.arange(100, 200, 10).reshape(2, 5)
@@ -235,49 +266,62 @@ class TestZarrWriter(unittest.TestCase):
         link_parent_2 = self.builder['test_bucket/foo_holder']
         link_parent_1.add_link(self.__dataset_builder, 'my_dataset_1')
         link_parent_2.add_link(self.__dataset_builder, 'my_dataset_2')
-        writer = ZarrIO(self.path, manager = self.manager, mode = 'a')
+        writer = ZarrIO(self.path, manager=self.manager, mode='a')
         writer.write_builder(self.builder)
         writer.close()
-
         self.read()
-        self.assertTrue(self.root['test_bucket'].links['my_dataset_1'].builder == self.root['test_bucket/foo_holder'].links['my_dataset_2'].builder)
-        print(self.root['test_bucket'].links['my_dataset_1'].builder == self.root['test_bucket/foo_holder'].links['my_dataset_2'].builder)
+        self.assertTrue(self.root['test_bucket'].links['my_dataset_1'].builder ==
+                        self.root['test_bucket/foo_holder'].links['my_dataset_2'].builder)
 
     def test_read_reference(self):
         self.test_write_reference()
         self.read()
-        print(self.root['ref_dataset'])
+        builder = self.getReferenceBuilder()['ref_dataset']
+        read_builder = self.root['ref_dataset']
+        # Load the linked arrays and confirm we get the same data as we had in the original builder
+        for i, v in enumerate(read_builder['data']):
+            self.assertTrue(np.all(builder['data'][i]['builder']['data'] == v['data'][:]))
 
     def test_read_reference_compound(self):
         self.test_write_reference_compound()
         self.read()
-        print(self.root['ref_dataset'])
+        builder = self.getReferenceCompoundBuilder()['ref_dataset']
+        read_builder = self.root['ref_dataset']
+        # Load the elements of each entry in the compound dataset and compar the index, string, and referenced array
+        for i, v in enumerate(read_builder['data']):
+            self.assertEqual(v[0], builder['data'][i][0])  # Compare index value from compound tuple
+            self.assertEqual(v[1], builder['data'][i][1])  # Compare string value from compound tuple
+            self.assertTrue(np.all(v[2]['data'][:] == builder['data'][i][2]['builder']['data'][:]))  # Compare ref array
+        # print(read_builder)
 
     def test_read_reference_compound_buf(self):
-        if os.path.exists(self.path):
-            shutil.rmtree(self.path)
         data_1 = np.arange(100, 200, 10).reshape(2, 5)
         data_2 = np.arange(0, 200, 10).reshape(4, 5)
         dataset_1 = DatasetBuilder('dataset_1', data_1)
         dataset_2 = DatasetBuilder('dataset_2', data_2)
 
-        ref_dataset_1 = ReferenceBuilder(dataset_1)
-        ref_dataset_2 = ReferenceBuilder(dataset_2)
+        # ref_dataset_1 = ReferenceBuilder(dataset_1)
+        # ref_dataset_2 = ReferenceBuilder(dataset_2)
         ref_data = [
             (1, 'dataset_1', ReferenceBuilder(dataset_1)),
             (2, 'dataset_2', ReferenceBuilder(dataset_2)),
             (3, 'dataset_3', ReferenceBuilder(dataset_1)),
             (4, 'dataset_4', ReferenceBuilder(dataset_2))
         ]
-        ref_data_type = [{'name': 'id', 'dtype': 'int'}, {'name': 'name', 'dtype': str}, {'name': 'reference', 'dtype': 'object'}]
+        ref_data_type = [{'name': 'id', 'dtype': 'int'},
+                         {'name': 'name', 'dtype': str},
+                         {'name': 'reference', 'dtype': 'object'}]
         dataset_ref = DatasetBuilder('ref_dataset', ref_data, dtype=ref_data_type)
-        builder = GroupBuilder('root', source = self.path,
-                                datasets = {'dataset_1':dataset_1, 'dataset_2':dataset_2, 'ref_dataset':dataset_ref})
-        writer = ZarrIO(self.path, manager = self.manager, mode = 'a')
+        builder = GroupBuilder('root',
+                               source=self.path,
+                               datasets={'dataset_1': dataset_1,
+                                         'dataset_2': dataset_2,
+                                         'ref_dataset': dataset_ref})
+        writer = ZarrIO(self.path, manager=self.manager, mode='a')
         writer.write_builder(builder)
         writer.close()
 
         self.read()
         self.assertFalse(self.root["ref_dataset"].data[0][2] == self.root['ref_dataset'].data[1][2])
         self.assertTrue(self.root["ref_dataset"].data[0][2] == self.root['ref_dataset'].data[2][2])
-        print(self.root['ref_dataset'])
+        #  print(self.root['ref_dataset'])

--- a/tests/unit/test_io_zarr.py
+++ b/tests/unit/test_io_zarr.py
@@ -198,8 +198,9 @@ class TestZarrWriter(unittest.TestCase):
         reader = ZarrIO(self.path, manager = self.manager, mode = 'r')
         self.root = reader.read_builder()
         dataset = self.root['test_bucket/foo_holder/foo1/my_data']
-        print dataset
-        print dataset.data[()]
+        print(dataset)
+        print(dataset.data[()])
+        print(dataset.dtype)
 
     def read(self):
         reader = ZarrIO(self.path, manager = self.manager, mode = 'r')
@@ -224,7 +225,7 @@ class TestZarrWriter(unittest.TestCase):
     def test_read_link(self):
         self.test_write_links()
         self.read()
-        print self.root['test_bucket'].links['my_dataset'].builder.data[()]
+        print(self.root['test_bucket'].links['my_dataset'].builder.data[()])
 
     def test_read_link_buf(self):
         data = np.arange(100, 200, 10).reshape(2, 5)
@@ -240,17 +241,17 @@ class TestZarrWriter(unittest.TestCase):
 
         self.read()
         self.assertTrue(self.root['test_bucket'].links['my_dataset_1'].builder == self.root['test_bucket/foo_holder'].links['my_dataset_2'].builder)
-        print self.root['test_bucket'].links['my_dataset_1'].builder == self.root['test_bucket/foo_holder'].links['my_dataset_2'].builder
+        print(self.root['test_bucket'].links['my_dataset_1'].builder == self.root['test_bucket/foo_holder'].links['my_dataset_2'].builder)
 
     def test_read_reference(self):
         self.test_write_reference()
         self.read()
-        print self.root['ref_dataset']
+        print(self.root['ref_dataset'])
 
     def test_read_reference_compound(self):
         self.test_write_reference_compound()
         self.read()
-        print self.root['ref_dataset']
+        print(self.root['ref_dataset'])
 
     def test_read_reference_compound_buf(self):
         if os.path.exists(self.path):
@@ -279,4 +280,4 @@ class TestZarrWriter(unittest.TestCase):
         self.read()
         self.assertFalse(self.root["ref_dataset"].data[0][2] == self.root['ref_dataset'].data[1][2])
         self.assertTrue(self.root["ref_dataset"].data[0][2] == self.root['ref_dataset'].data[2][2])
-        print self.root['ref_dataset']
+        print(self.root['ref_dataset'])


### PR DESCRIPTION
## Motivation

* Use six string types for Python3 compatibility
* Update print statements for Python3 compatibility
* Add missing numcodec package requirement needed for storing strings using Zarr
* Cleaned up ZarrIO tests to replace print with asserts
* Update Zarr backend feature docs
* Fix flake8 formatting for HDMF source
* Fix flake8 formatting for ZarrIO tests



## Checklist

- [ ] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR description clearly describes problem and the solution?
- [ ] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ? By including "Fix #XXX" you allow GitHub to close the corresponding issue.
