### PR TITLE
Add missing zarr_dtype attribute. Fix write of numpy and bytestring v…

### DIFF
--- a/src/hdmf/backends/zarr/zarr_tools.py
+++ b/src/hdmf/backends/zarr/zarr_tools.py
@@ -173,13 +173,18 @@ class ZarrIO(HDMFIO):
                 try:
                     obj.attrs[key] = tmp
                 # Numpy scalars abd bytes are not JSON serializable. Try to convert to a serializable type instead
-                except TypeError:
+                except TypeError as e:
                     write_ok = False
                     try:
-                        tmp = tuple([ i.item() if isinstance(i, np.generic) else i.decode("utf-8") if isinstance(i, bytes)  else i for i in value])
+                        tmp = tuple([i.item()
+                                     if isinstance(i, np.generic)
+                                     else i.decode("utf-8")
+                                     if isinstance(i, bytes)
+                                     else i
+                                     for i in value])
                         obj.attrs[key] = tmp
                         write_ok = True
-                    except:
+                    except:  # noqa: E272
                         pass
                     if not write_ok:
                         raise TypeError(str(e) + " type=" + str(type(value)) + "  data=" + str(value))
@@ -202,13 +207,17 @@ class ZarrIO(HDMFIO):
                 except TypeError as e:
                     write_ok = False
                     try:
-                        val = value.item() if isinstance(value, np.generic) else value.decode("utf-8") if isinstance(value, bytes)  else value
+                        val = value.item() \
+                            if isinstance(value, np.generic) \
+                            else value.decode("utf-8") \
+                            if isinstance(value, bytes) \
+                            else value
                         obj.attrs[key] = val
                         write_ok = True
-                    except:
+                    except:  # noqa: E272
                         pass
                     if not write_ok:
-                        raise TypeError(str(e) + "key="+ key + " type=" + str(type(value)) + "  data=" + str(value))
+                        raise TypeError(str(e) + "key=" + key + " type=" + str(type(value)) + "  data=" + str(value))
 
     def __get_path(self, builder):
         curr = builder
@@ -615,7 +624,7 @@ class ZarrIO(HDMFIO):
             return ret
 
         if 'zarr_dtype' not in zarr_obj.attrs:
-            raise ValueError("Dataset missing zarr_dtype: " + str(name)+ "   " + str(zarr_obj))
+            raise ValueError("Dataset missing zarr_dtype: " + str(name) + "   " + str(zarr_obj))
 
         kwargs = {"attributes": self.__read_attrs(zarr_obj),
                   "dtype": zarr_obj.attrs['zarr_dtype'],

--- a/src/hdmf/backends/zarr/zarr_tools.py
+++ b/src/hdmf/backends/zarr/zarr_tools.py
@@ -536,7 +536,7 @@ class ZarrIO(HDMFIO):
                 raise_from(Exception(msg), exc)
         dset = parent.require_dataset(name, shape=(1, ), dtype=dtype, compressor=None, **io_settings)
         dset[:] = data
-        type_str = cls.__serial_dtype__(dtype)
+        type_str = 'scalar'
         dset.attrs['zarr_dtype'] = type_str
         return dset
 
@@ -623,6 +623,10 @@ class ZarrIO(HDMFIO):
         # data = deepcopy(zarr_obj[:])
         data = zarr_obj
         # kwargs['data'] = zarr_obj[:]
+        # Read scalar dataset
+        if 'zarr_dtype' in zarr_obj.attrs:
+            if zarr_obj.attrs['zarr_dtype'] == 'scalar':
+                data = zarr_obj[0]
 
         dtype = kwargs['dtype']
         obj_refs = False


### PR DESCRIPTION
## Motivation`

Fix errors that occur when integrating with PyNWB for full NWB integration test.

* Support write of np.numeric data types as attributes
* Support write of object/region references as attributes
* Support read of object references from attributes
* Set missing ``zarr_dtype`` attribute on scalar datasets
* Read scalar datasets as scalars instead of Zarr arrays
* Fix read of references to groups



## Checklist

- [ ] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR description clearly describes problem and the solution?
- [ ] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ? By including "Fix #XXX" you allow GitHub to close the corresponding issue.
